### PR TITLE
Update `hair.py` to Support Compatibility with Blender 4.2.1 LTS and Earlier Versions

### DIFF
--- a/hair-converter/hair.py
+++ b/hair-converter/hair.py
@@ -313,7 +313,16 @@ class HairConverter:
         if render_amount > 0:
             pset.rendered_child_count = render_amount
             pset.child_type = 'SIMPLE'
-            pset.child_nbr = render_amount
+            
+            # Support for both older Blender versions and Blender 4.2.1 LTS and later
+            # Blender 4.2.1 and later replaced 'child_nbr' with 'child_count'
+            if hasattr(pset, 'child_nbr'):
+                # For older versions of Blender
+                pset.child_nbr = render_amount
+            elif hasattr(pset, 'child_count'):
+                # For Blender 4.2.1 LTS and later
+                pset.child_count = render_amount
+
             pset.child_length = .95
             pset.child_length_threshold = .5
             pset.child_radius = self.scale(self.strandRadius)


### PR DESCRIPTION
This pull request updates the `hair.py` script to ensure compatibility across different versions of Blender, specifically addressing changes in the `ParticleSettings` API between older versions and Blender 4.2.1 LTS leading to the `AttributeError: 'ParticleSettings' object has no attribute 'child_nbr'` error.

### Key Changes:
1. **Child Particle Count Attribute:**
   - Replaced the deprecated `child_nbr` attribute with `child_count` for Blender 4.2.1 LTS and later.
   - Included a conditional check to use `child_nbr` for older versions of Blender to maintain backward compatibility.

2. **Comments:** 
   - Added comments to explain the changes and the rationale behind them, making the code easier to maintain and update in the future.

### Testing:
- The updated script has been tested in both older Blender versions and Blender 4.2.1 LTS to ensure proper functionality across all supported versions.

**Request:**
Please review these changes, and let me know if any further modifications are needed. This update is intended to make the addon more robust and compatible with a wider range of Blender installations.
